### PR TITLE
Community docs 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+---
+title: Contributor Code of Conduct
+permalink: /code-of-conduct/
+---
+
+# Contributor Code of Conduct
+
+All PDS Interop projects adhere to [The Code Manifesto](https://github.com/greydnls/code-manifesto)
+as its guidelines for contributor and community interactions.
+
+## The Code Manifesto
+
+We want to work in an ecosystem that empowers developers to reach their potential
+-- one that encourages growth and effective collaboration. A space that is safe
+for all.
+
+A space such as this benefits everyone that participates in it. It encourages
+new developers to enter our field. It is through discussion and collaboration
+that we grow, and through growth that we improve.
+
+In the effort to create such a place, we hold to these values:
+
+1. **Discrimination limits us.**
+  This includes discrimination on the basis of race, gender, sexual orientation,
+  gender identity, age, nationality, technology and any other arbitrary
+  exclusion of a group of people.
+
+2. **Boundaries honor us.**
+  Your comfort levels are not everyone’s comfort levels. Remember that, and if
+  brought to your attention, heed it.
+
+3. **We are our biggest assets.**
+  None of us were born masters of our trade. Each of us has been helped along
+  the way. Return that favor, when and where you can.
+
+4. **We are resources for the future.**
+  As an extension of #3, share what you know. Make yourself a resource to help
+  those that come after you.
+
+5. **Respect defines us.**
+  Treat others as you wish to be treated. Make your discussions, criticisms and
+  debates from a position of respectfulness. Ask yourself, is it true? Is it
+  necessary? Is it constructive? Anything less is unacceptable.
+
+6. **Reactions require grace.**
+  Angry responses are valid, but abusive language and vindictive actions are
+  toxic. When something happens that offends you, handle it assertively, but be
+  respectful. Escalate reasonably, and try to allow the offender an opportunity
+  to explain themselves, and possibly correct the issue.
+
+7. **Opinions are just that: opinions.**
+   Each and every one of us, due to our background and upbringing, have varying
+   opinions. That is perfectly acceptable. Remember this: if you respect your
+   own opinions, you should respect the opinions of others.
+
+8. **To err is human.**
+   You might not intend it, but mistakes do happen and contribute to build
+   experience. Tolerate honest mistakes, and don't hesitate to apologize if you
+   make one yourself.
+
+If you feel anyone is being disrespectful or not acting in line with these
+values, please contact us so matter can be resolved.
+
+All complaints will be reviewed and investigated promptly and fairly, respecting
+the privacy and security of the reporter of any incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+---
+title: Contributing
+permalink: /contributing/
+---
+
+# Contributing to PDS Interop
+
+Thank you for your interest in contributing!
+
+All PDS Interop projects are open source and community-friendly.
+
+Questions can be asked (or feedback given) by opening an issues on Github.
+
+<!--
+If you have a question, please visit [our chat channel](#todo).
+The Github issue tracker is only for **bug reports and feature requests**.
+-->
+
+We accept contributions via merge-request<sup>1</sup> on [Github](https://github.com/pdsinterop/).
+
+_Any_ contribution is welcome and your will be given full credit for your efforts.
+
+## Contributor Code of Conduct
+
+Please note that this project adheres to a [Contributor Code of Conduct](https://pdsinterop.org/code-of-conduct/). When participating in this project and its community, you are expected to abide by its terms.
+
+## Security
+
+If you discover any security related issues, please email <security@pdsinterop.org> instead of using the issue tracker.
+
+## Reporting issues
+
+**To ensure your privacy and security, please do not include passwords or personally identifiable information in your bug report and sample code.**
+
+Some general guidelines:
+
+- Before opening an new issue, please use the GitHub search feature to see if
+  the issue has already been reported
+
+- If your issue is not specific to one repository but more about things in
+  general, [open an issue with project administration](https://github.com/pdsinterop/project-admin/issues)
+
+- If your issue is about the website or generic documentation, [open an issue at
+  the website repository](https://github.com/pdsinterop/pdsinterop.github.io/issues)
+
+When reporting issues, please try to be as descriptive as possible, and include
+as much relevant information as you can to help us reproduce the issue.
+
+A good bug report includes:
+
+- Expected outcome
+- Actual outcome
+- Steps to reproduce (including any relevant sample code)
+- Any other information that will help us debug and reproduce the issue (error messages, stack traces, system/environment information, screenshots, etc.)
+
+A step by step guide on how to reproduce the issue will greatly increase the
+chances of your issue being resolved in a timely manner.
+
+If your issue involves installing, updating or resolving dependencies, the
+chance of us being able to reproduce your issue will be much higher if you
+share the file defining your dependency with us.
+
+Due to time constraints, we are not always able to respond as quickly as we would like. Please do not take delays personal and feel free to remind us if you feel that we forgot to respond!
+
+## Development
+
+There is a common development workflow that goes (more or less) like this:
+
+1. Fork the project.
+2. Make code changes (add a feature, fix a bug, update the documentation).
+3. Add tests for the code changes.
+4. Commit your work
+5. Send a merge request. Bonus points for topic branches.
+
+### 1. Fork the project
+
+1. Visit the project on GitHub
+2. Click on the "Fork" button
+3. Clone you forked project to your development environment
+
+### 2. Code changes
+
+Things that are common to all PDS Interop projects are listed below.
+
+Beyond that, each project has its own project specific development instructions,
+either in the project's `README.md` file or its `docs/` folder. Please visit the
+project you are contributing to for futher development details.
+
+
+#### Common coding guidelines
+
+- **PHP code** should follow the [PSR-12 coding standard](http://www.php-fig.org/psr/psr-12/).
+
+<!--
+- **Javascript code** should follow the [(?)](#TODO).
+
+- **TypeScript code** should follow the [(?)](#TODO).
+
+- **Documentation** (markdown files) should follow the PDS Interop Remark lint configuration. It should US English spelling and non-offensive wording.
+
+- **YAML files** should pass the PDS Interop YAML Lint configuration.
+Full details can be found at [https://pdsinterop.org/coding-standards/](https://pdsinterop.org/coding-standards/)
+-->
+
+### 3. Add tests
+
+Please **write tests** for any new features you add.
+
+Any contribution must provide tests for additional introduced conditions
+
+Any un-confirmed issue needs a failing test case before being accepted
+
+This is important so we don't unintentionally break your code changes in a
+future version.
+
+Please **ensure that all tests pass** before making commits. There is a pipeline
+that automatically runs tests for pull requests and commits. Running the tests locally will help save time.
+
+### 4. Commit your work
+
+Before making commits, please make sure that you have [set up your user name and email address](http://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup) for use with Git. Strings such as `silly nick name <root@localhost>` look really stupid in the commit history of a project.
+
+Pull requests must be sent from a new fix/feature branch, not from `master`.
+Make sure you are working on a new branch.
+
+Next, think about your commit message for a while. What should it convey? What
+do you want to tell us and future developers about the work you did?
+
+Your commit message can be as long as you want, just make sure to give it a
+summary as a title if you need more than one sentence to discribe your work.
+
+### 5. Send a merge request
+
+Your pull request description should clearly detail the changes you have made.
+We will use this description to add to our CHANGELOG. If there is no description
+or it does not adequately describe your feature, we will ask you to update the description.
+
+Other things to keep in mind are:
+
+- **Consider our release cycle**
+  We try to follow [Semantic Versioning](http://semver.org/). Randomly breaking
+  public APIs is not an option.
+
+- **Document any change in behaviour**
+  Make sure the `README.md`or other relevant documentation are kept up-to-date.
+
+- **Ensure all checks pass**
+  We have a GitHub Actions pipeline that runs automatically for pull requests.
+  All checks need to pass before changes will be considered.
+
+- **One pull request per change/feature/fix**
+  If you want to do more than one thing, send multiple pull requests.
+
+- **Send a coherent history**
+  Make sure each individual commit in your pull request is meaningful. Please do
+  not squash your commits or send all your changes in a _single_ commit.
+
+- **Use topic/feature branches.**
+  Please do not ask us to pull from your fork's main branch.
+
+## Footnotes
+
+1. merge requests (or MRs) are the same as pull pequests (or PRs). They are sometimes also referred to as "patches".
+
+<!--
+
+If you'd like to contribute, please read the following documents:
+
+* [Coding Standards][1]
+* [Core Team and Cntributers][2]
+* [Running Tests][3]
+* [Security Issues][4]
+
+[1]: https://pdsinterop.org/coding-standards/
+[2]: https://pdsinterop.org/contributing/contributers/
+[3]: https://pdsinterop.org/contributing/tests/
+[4]: https://pdsinterop.org/contributing/security/
+
+- The project will follow strict [object calisthenics](http://www.slideshare.net/guilhermeblanco/object-calisthenics-applied-to-php)
+
+## Adding New Features
+
+If you have an idea for a new feature, it's a good idea to check out our [issues](https://github.com/ramsey/uuid/issues) or active [pull requests](https://github.com/ramsey/uuid/pulls) first to see if the feature is already being worked on. If not, feel free to submit an issue first, asking whether the feature is beneficial to the project. This will save you from doing a lot of development work only to have your feature rejected. We don't enjoy rejecting your hard work, but some features just don't fit with the goals of the project.
+-->

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+---
+title: License
+permalink: /license/
+---
+
+Copyright 2020 PDS Interop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This MR adds a code of conduct and contributions file to further [complete our Community profile](https://github.com/pdsinterop/pdsinterop.github.io/community)

To allow users to report security issues,  a `security@pdsinterop.org` email address will need to be created and monitored.

As the full [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct/) was felt to be overkill at this stage in the organization's lifecycle, I have opted for the Code Manifesto.

Both the code of conduct and the contributing file are meant to be hosted on https://pdsinterop.org so they can be linked to from all PDS Interop repositories.

Once both documents have been approved they will be uses as a basis for [a repository for default files](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file).